### PR TITLE
SoulBlazer: Adding in Weak and Broken sword/armor stat progression sets

### DIFF
--- a/worlds/soulblazer/Options.py
+++ b/worlds/soulblazer/Options.py
@@ -119,12 +119,16 @@ class EquipmentScaling(Choice):
     Vanilla: Swords/Armor follow the vanilla 1/2/3/4/6/8/10/12 strength/defense progression.
     Improved: Swords/Armor follow an improved 1/3/5/7/9/12/12/12 strength/defense progression.
     Strong: Swords/Armor follow a strong 2/4/6/9/12/12/12/12 strength/defense progression.
+    Weak: Swords/Armor follow a weak 1/1/2/2/3/4/5/6 strength/defense progression.
+    Broken: Swords/Armor strength is set to 1/1/1/1/1/1/1/1 strength/defense progression.
     """
 
     display_name = "Equipment Scaling"
     option_vanilla = 0
     option_improved = 1
     option_strong = 2
+    option_weak = 3
+    option_broken = 4
     default = 0
 
 

--- a/worlds/soulblazer/Rom.py
+++ b/worlds/soulblazer/Rom.py
@@ -23,6 +23,9 @@ USHASH = "83cf41d53a1b94aeea1a645037a24004"
 equipment_power_vanilla = [1, 2, 3, 4, 5, 8, 10, 12]
 equipment_power_improved = [1, 3, 5, 7, 9, 12, 12, 12]
 equipment_power_strong = [2, 4, 6, 9, 12, 12, 12, 12]
+equipment_power_weak = [1, 1, 2, 2, 3, 4, 5, 6]
+equipment_power_broken = [1, 1, 1, 1, 1, 1, 1, 1]
+
 # Level requirements are stored as 2-byte SNES BCD - Their hex representation is interpreted as decimal.
 sword_level_requirements = [0x01, 0x05, 0x11, 0x15, 0x16, 0x19, 0x22, 0x24]
 
@@ -117,11 +120,14 @@ def patch_rom(world: "SoulBlazerWorld", rom: LocalRom):
         rom.apply_patch("semiprogressive")
 
     # Determine stat pool to use
-    stats = (
-        equipment_power_improved
-        if world.options.equipment_scaling == "improved"
-        else (equipment_power_strong if world.options.equipment_scaling == "strong" else equipment_power_vanilla)
-    )
+    equipment_power_lookup = {
+        "Vanilla": equipment_power_vanilla,
+        "Improved": equipment_power_improved,
+        "Strong": equipment_power_strong,
+        "Weak": equipment_power_weak,
+        "Broken": equipment_power_broken,
+    }
+    stats = [*equipment_power_lookup[world.options.equipment_scaling.current_option_name]]
     
     # The indexes into our stat pool which could potentially be shuffled
     indicies_wep = list(range(len(stats)))


### PR DESCRIPTION
# SoulBlazer: Weak & Broken Sword/Armor Progression

## What is this fixing or adding?
- Added feature to have weaker (more challenging) stat progression on swords/armor.
- It is also changing the way the stat set is chosen, and look way more clean.

## How was this tested?
- [x] Successfully generated a rom.
- [x] Playtested with with "broken" settings.
- [x] Confirmed that Armor and Sword retain the minimum setting.

## Other
The only concern is whether the "broken" setting should be implemented with 0s or with the current setting of 1. I'll leave it as 1 for now.
