### PR TITLE
Soulblazer dataclass wizard removal

### DIFF
--- a/.github/workflows/release-apworld.yml
+++ b/.github/workflows/release-apworld.yml
@@ -23,18 +23,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: worlds/${{ env.AP_WORLD_DIR }}
-      - name: Checkout dataclass-wizard dependancy library
-        uses: actions/checkout@v4
-        with:
-          repository: Tranquilite0/dataclass-wizard
-          path: ./dataclass-wizard
-          sparse-checkout: |
-            LICENCE
-            dataclass_wizard
-      - name: Copy dataclass-wizard to APWorld Directory
-        run: |
-          cp -R ./dataclass-wizard/dataclass_wizard ./worlds/${{ env.AP_WORLD_DIR }}/Data
-          cp ./dataclass-wizard/LICENSE ./worlds/${{ env.AP_WORLD_DIR }}/Data/dataclass_wizard
       - name: Create AP World Archive
         run: |
           mkdir dist

--- a/worlds/soulblazer/Data/Enums.py
+++ b/worlds/soulblazer/Data/Enums.py
@@ -1,4 +1,7 @@
 from enum import Enum, IntEnum
+from typing import Any
+
+from ..Data import strFromYaml
 
 class LocationType(Enum):
     CHEST = "Chest"
@@ -7,6 +10,14 @@ class LocationType(Enum):
     """Location checked by talking to an NPC or stepping on an item tile."""
     LAIR = "Lair"
     """Location checked by sealing a monster lair."""
+
+    @staticmethod
+    def from_yaml(yaml: Any) -> "LocationType":
+        tag = strFromYaml(yaml)
+
+        return LocationType(tag)
+
+
 
 class RuleFlag(Enum):
     NONE = "NONE"
@@ -36,6 +47,12 @@ class RuleFlag(Enum):
     Both Dancing Grandmas
     The 3 Red-Hot Items
     """
+
+    @staticmethod
+    def from_yaml(yaml: Any) -> "RuleFlag":
+        tag = strFromYaml(yaml)
+
+        return RuleFlag(tag)
 
 
 class IDOffset(IntEnum):

--- a/worlds/soulblazer/Data/Enums.py
+++ b/worlds/soulblazer/Data/Enums.py
@@ -1,7 +1,7 @@
 from enum import Enum, IntEnum
 from typing import Any
 
-from ..Data import strFromYaml
+from ..Data import str_from_yaml
 
 class LocationType(Enum):
     CHEST = "Chest"
@@ -13,7 +13,7 @@ class LocationType(Enum):
 
     @staticmethod
     def from_yaml(yaml: Any) -> "LocationType":
-        tag = strFromYaml(yaml)
+        tag = str_from_yaml(yaml)
 
         return LocationType(tag)
 
@@ -50,7 +50,7 @@ class RuleFlag(Enum):
 
     @staticmethod
     def from_yaml(yaml: Any) -> "RuleFlag":
-        tag = strFromYaml(yaml)
+        tag = str_from_yaml(yaml)
 
         return RuleFlag(tag)
 

--- a/worlds/soulblazer/Data/ItemData.py
+++ b/worlds/soulblazer/Data/ItemData.py
@@ -4,7 +4,7 @@ from typing import Any
 from BaseClasses import ItemClassification
 from Utils import parse_yaml
 from .Enums import ItemID, IDOffset, NPCID, SoulID
-from ..Data import get_data_file_bytes, fromYamlOr, intFromYaml, listFromYaml, strFromYaml
+from ..Data import get_data_file_bytes, from_yaml_or, int_from_yaml, list_from_yaml, str_from_yaml
 from ..Util import int_to_bcd
 
 @dataclass(frozen=True)
@@ -25,11 +25,11 @@ class SoulBlazerItemData:
     @staticmethod
     def from_yaml(yaml: Any) -> "SoulBlazerItemData":
         return SoulBlazerItemData(
-            name = strFromYaml(yaml["name"]),
-            id = intFromYaml(yaml["id"]),
-            operand = intFromYaml(yaml["operand"]),
-            classification = intFromYaml(yaml["classification"]),
-            description = fromYamlOr(yaml["description"], strFromYaml, ""),
+            name = str_from_yaml(yaml["name"]),
+            id = int_from_yaml(yaml["id"]),
+            operand = int_from_yaml(yaml["operand"]),
+            classification = int_from_yaml(yaml["classification"]),
+            description = from_yaml_or(yaml["description"], str_from_yaml, ""),
         )
 
     def duplicate(self, **changes) -> "SoulBlazerItemData":
@@ -70,14 +70,14 @@ class SoulBlazerItemsData:
     @staticmethod
     def from_yaml(yaml: Any) -> "SoulBlazerItemsData":
         return SoulBlazerItemsData(
-            swords = listFromYaml(yaml["swords"], SoulBlazerItemData.from_yaml),
-            armors = listFromYaml(yaml["armors"], SoulBlazerItemData.from_yaml),
-            magics = listFromYaml(yaml["magics"], SoulBlazerItemData.from_yaml),
-            inventory_items = listFromYaml(yaml["inventory_items"], SoulBlazerItemData.from_yaml),
-            misc_items = listFromYaml(yaml["misc_items"], SoulBlazerItemData.from_yaml),
-            npc_releases = listFromYaml(yaml["npc_releases"], SoulBlazerItemData.from_yaml),
-            souls = listFromYaml(yaml["souls"], SoulBlazerItemData.from_yaml),
-            special_items = listFromYaml(yaml["special_items"], SoulBlazerItemData.from_yaml),
+            swords = list_from_yaml(yaml["swords"], SoulBlazerItemData.from_yaml),
+            armors = list_from_yaml(yaml["armors"], SoulBlazerItemData.from_yaml),
+            magics = list_from_yaml(yaml["magics"], SoulBlazerItemData.from_yaml),
+            inventory_items = list_from_yaml(yaml["inventory_items"], SoulBlazerItemData.from_yaml),
+            misc_items = list_from_yaml(yaml["misc_items"], SoulBlazerItemData.from_yaml),
+            npc_releases = list_from_yaml(yaml["npc_releases"], SoulBlazerItemData.from_yaml),
+            souls = list_from_yaml(yaml["souls"], SoulBlazerItemData.from_yaml),
+            special_items = list_from_yaml(yaml["special_items"], SoulBlazerItemData.from_yaml),
         )
 
     @property

--- a/worlds/soulblazer/Data/LocationData.py
+++ b/worlds/soulblazer/Data/LocationData.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from Utils import parse_yaml
 from .Enums import LocationType, RuleFlag, IDOffset, LairID, ChestID, NPCRewardID
-from ..Data import get_data_file_bytes, intFromYaml, listFromYaml, strFromYaml
+from ..Data import get_data_file_bytes, int_from_yaml, list_from_yaml, str_from_yaml
 
 
 @dataclass(frozen=True)
@@ -21,11 +21,11 @@ class SoulBlazerLocationData:
     @staticmethod
     def from_yaml(yaml: Any) -> "SoulBlazerLocationData":
         return SoulBlazerLocationData(
-            id = intFromYaml(yaml["id"]),
-            name = strFromYaml(yaml["name"]),
+            id = int_from_yaml(yaml["id"]),
+            name = str_from_yaml(yaml["name"]),
             type = LocationType.from_yaml(yaml["type"]),
             flag = RuleFlag.from_yaml(yaml["flag"]),
-            description = strFromYaml(yaml["description"]),
+            description = str_from_yaml(yaml["description"]),
         )
 
     @property
@@ -48,9 +48,9 @@ class SoulBlazerLocationsData:
     @staticmethod
     def from_yaml(yaml: Any) -> "SoulBlazerLocationsData":
         return SoulBlazerLocationsData(
-            chests = listFromYaml(yaml["chests"], SoulBlazerLocationData.from_yaml),
-            lairs = listFromYaml(yaml["lairs"], SoulBlazerLocationData.from_yaml),
-            npc_rewards = listFromYaml(yaml["npc-rewards"], SoulBlazerLocationData.from_yaml),
+            chests = list_from_yaml(yaml["chests"], SoulBlazerLocationData.from_yaml),
+            lairs = list_from_yaml(yaml["lairs"], SoulBlazerLocationData.from_yaml),
+            npc_rewards = list_from_yaml(yaml["npc-rewards"], SoulBlazerLocationData.from_yaml),
         )
 
     @property

--- a/worlds/soulblazer/Data/__init__.py
+++ b/worlds/soulblazer/Data/__init__.py
@@ -3,19 +3,19 @@ from typing import Any, Callable, Optional, TypeVar
 
 T = TypeVar('T')
 
-def strFromYaml(yaml: Any) -> str:
+def str_from_yaml(yaml: Any) -> str:
     assert isinstance(yaml, str);
     return yaml
 
-def intFromYaml(yaml: Any) -> int:
+def int_from_yaml(yaml: Any) -> int:
     assert isinstance(yaml, int);
     return yaml
 
-def listFromYaml(yaml: Any, f: Callable[[Any], T]) -> list[T]:
+def list_from_yaml(yaml: Any, f: Callable[[Any], T]) -> list[T]:
     assert isinstance(yaml, list)
     return list(map(f, yaml))
 
-def fromYamlOr(yaml: Any, f: Callable[[Any], T], default: T) -> T:
+def from_yaml_or(yaml: Any, f: Callable[[Any], T], default: T) -> T:
     if yaml is None:
         return default
 

--- a/worlds/soulblazer/Data/__init__.py
+++ b/worlds/soulblazer/Data/__init__.py
@@ -1,12 +1,25 @@
 import pkgutil
+from typing import Any, Callable, Optional, TypeVar
 
-# Installing packages from requirements.txt is not supported from frozen AP installs for
-# dynamically loaded AP Worlds. This can be simplified if/when the world is merged into AP.
-try:
-    import dataclass_wizard as dw
-except ImportError:
-    from . import dataclass_wizard as dw
-    
+T = TypeVar('T')
+
+def strFromYaml(yaml: Any) -> str:
+    assert isinstance(yaml, str);
+    return yaml
+
+def intFromYaml(yaml: Any) -> int:
+    assert isinstance(yaml, int);
+    return yaml
+
+def listFromYaml(yaml: Any, f: Callable[[Any], T]) -> list[T]:
+    assert isinstance(yaml, list)
+    return list(map(f, yaml))
+
+def fromYamlOr(yaml: Any, f: Callable[[Any], T], default: T) -> T:
+    if yaml is None:
+        return default
+
+    return f(yaml)
 
 def get_data_file_bytes(name: str) -> bytes:
     return pkgutil.get_data(__name__, f"{name}")

--- a/worlds/soulblazer/requirements.txt
+++ b/worlds/soulblazer/requirements.txt
@@ -1,2 +1,0 @@
-dataclass-wizard>=0.35.0
-tzdata>=2025.1


### PR DESCRIPTION
This removes the need for vendoring the dataclass_wizard package by replacing it with manual mapping functions.